### PR TITLE
Missing context

### DIFF
--- a/lib/iopi/iopi.js
+++ b/lib/iopi/iopi.js
@@ -142,10 +142,10 @@ IoPi = (function () {
         pin = pin - 1;
         if (pin < 8) {
             this.portADir = updateByte(this.portADir, pin, direction);
-            this.i2cWriteByte(IODIRA, portADir);
+            this.i2cWriteByte(IODIRA, this.portADir);
         } else {
             this.portBDir = updateByte(this.portBDir, pin - 8, direction);
-            this.i2cWriteByte(IODIRB, portBDir);
+            this.i2cWriteByte(IODIRB, this.portBDir);
         }
     };
 


### PR DESCRIPTION
Missing context, leading to error when setting pins directions.